### PR TITLE
Minor typos fix

### DIFF
--- a/lec/calc-theorem.tex
+++ b/lec/calc-theorem.tex
@@ -411,7 +411,7 @@
   boils down to the following true statement:
   if \(\llbr{M} = \llbr{M'}\)
   and \(\llbr{N} = \llbr{N'}\)
-  then \(\angled{\llbr{M},\llbr{M'}} = \angled{\llbr{N},\llbr{N'}}\).
+  then \(\angled{\llbr{M},\llbr{N}} = \angled{\llbr{M'},\llbr{N'}}\).
   The other cases are similarly straightforward.
 
   The rules in group (3) follow from the definition of categorical product.
@@ -434,7 +434,7 @@
   All that's left is \textsc{Let-Sub}---the rule stating that let-binding is equivalent to substitution.
   Validating this rule boils down to showing the following:
   \begin{lemma}[``Let is substitution''] \label{lem:let-is-subst}
-    For all contexts \(\Gamma\), types \(A\),
+    For all contexts \(\Gamma\), types \(A\), \(B\)
     and terms \(M\) and \(N\)
     such that \(\Gamma \vdash M : A\)
     and \(\Gamma,x\ofty A \vdash N : B\),

--- a/lec/universal-constructions.tex
+++ b/lec/universal-constructions.tex
@@ -1340,7 +1340,7 @@ So, we have a candidate exponential object. Now, let's check that it
 satisfies the universal property: we 
 must show that for any formulae $\alpha$ and $\beta$, 
 for any formula $\gamma$ with morphism $\alpha \times \gamma \to \beta$, 
-there exists an object $\neg \alpha \lor \gamma$ such that:
+there exists an object $\neg \alpha \lor \beta$ such that:
 \begin{enumerate}
   \item There is a morphism $\gamma \to \neg \alpha \lor \beta$. This morphism represents \emph{logical weakening of $\gamma$}.
   \item There is a morphism $(\neg \alpha \lor \beta) \times \alpha \to \beta$. 


### PR DESCRIPTION
- Page 46, order of pair elements mixed up in the equality:
<img width="774" height="131" alt="image" src="https://github.com/user-attachments/assets/c7cf6759-d806-45af-8839-488ddff75198" />

- Page 46, missing type B in the "for all" statement: 
<img width="792" height="119" alt="image" src="https://github.com/user-attachments/assets/44a46f1b-98cc-4876-892e-8b3a251c47e4" />

- Page 57, exponential object given in terms of gamma, not beta:
<img width="801" height="139" alt="image" src="https://github.com/user-attachments/assets/7c432f78-572b-4377-a026-d803596dadf2" />
