### PR TITLE
Slightly better integrate algebras chapter

### DIFF
--- a/algebra/main.typ
+++ b/algebra/main.typ
@@ -15,7 +15,8 @@
 #import cosmos.rainbow: *
 #show: show-theorion
 // #set par.line(numbering: it => text(fill: gray, [#it]))
-#set page(numbering: "1 of 1")
+// #set page(numbering: "1 of 1")
+#set page(numbering: none)
 #set heading(numbering: "1.1.1.1")
 #set math.equation(numbering: "(1)")
 #show link: this => underline(text(this, fill: blue))

--- a/lec/algebra.tex
+++ b/lec/algebra.tex
@@ -1,0 +1,5 @@
+\includepdf[
+  pages=-,
+  addtotoc={1, chapter, 1, Algebras and automata, algebras-automata},
+  pagecommand={\pagestyle{fancy}}
+]{algebra/main.pdf}

--- a/main.tex
+++ b/main.tex
@@ -92,7 +92,7 @@ with Shubh Agrawal, Jialu Bao, Bex Golovanov, Mingtong Lin, Joseph Rotella, and 
 \input{explainer/realizability}
 \input{lec/noninterference.tex}
 \input{lec/refining-inductives.tex}
-\includepdf[pages=-]{algebra/main.pdf}
+\input{lec/algebra.tex}
 
 \bibliographystyle{plain}
 \bibliography{lib/bib, explainer/realizability, lib/refining-inductives}


### PR DESCRIPTION
This PR adds the Algebras and Automata chapter to the table of contents and disables Typst's page numbering in favor of the book-wide header numbers.